### PR TITLE
Checkout total number float point fix

### DIFF
--- a/android/src/main/java/com/nextar/sumup/RNSumUpModule.java
+++ b/android/src/main/java/com/nextar/sumup/RNSumUpModule.java
@@ -138,7 +138,7 @@ public class RNSumUpModule extends ReactContextBaseJavaModule {
     try {
       SumUpPayment.Currency currencyCode = this.getCurrency(request.getString("currencyCode"));
       SumUpPayment payment = SumUpPayment.builder()
-              .total(new BigDecimal(Double.parseDouble(request.getString("totalAmount"))))
+              .total(new BigDecimal(request.getString("totalAmount")).setScale(2, RoundingMode.HALF_EVEN))
               .currency(currencyCode)
               .title(request.getString("title"))
               .foreignTransactionId(UUID.randomUUID().toString())


### PR DESCRIPTION
I had an issue while making a checkout with total like: 10.02, 15.03, 10.06. It gets rounded up and total amount is incorrect. Try making payment request yourself and I hope it solves an issue.