### PR TITLE
SumUp wrapper updated to 3.0.0 version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,38 +2,66 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
-
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
 allprojects {
     repositories {
-        maven { url 'https://maven.sumup.com/releases' }
         jcenter()
+
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+
+        maven { url 'https://maven.sumup.com/releases' }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 26
+    buildToolsVersion "27.0.2"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
     }
-    lintOptions {
-        abortOnError false
-        warning 'InvalidPackage'
+    // Possible resolution strategy. Only necessary if not compiling against API 27
+    configurations.all {
+        resolutionStrategy {
+            force 'com.android.support:support-v4:26.1.0'
+            force 'com.android.support:appcompat-v7:26.1.0'
+            force 'com.android.support:cardview-v7:26.1.0'
+            force 'com.android.support:design:26.1.0'
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/services/javax.annotation.processing.Processor'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+    }
+
+    buildTypes {
+        debug {
+            // All ProGuard rules required by the SumUp SDK are packaged with the library
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt')
+        }
     }
 }
 
@@ -46,8 +74,8 @@ dependencies {
     annotationProcessor 'com.neenbedankt.bundles:argument:1.0.4'
     compile 'com.neenbedankt.bundles:argument:1.0.4'
     compile 'com.facebook.react:react-native:+'
-    compile('com.sumup:merchant-sdk:2.5.2@aar') {
-        transitive = true
-    }
+    compile 'com.android.support:appcompat-v7:26.1.0'
+
+    compile 'com.sumup:merchant-sdk:3.0.0'
 }
   


### PR DESCRIPTION
I have updated Wrapper to SumUp Android SDK version 3.0.0. For it to work we need to add Google maven to Project's main build.gradle like so:

```
allprojects {
    repositories {
        mavenLocal()
        jcenter()
        maven {
            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
            url "$rootDir/../node_modules/react-native/android"
        }
// I ADDED THIS CODE BELOW
        maven {
            url 'https://maven.google.com/'
            name 'Google'
        }
// I ADDED THIS CODE ABOVE
        maven { url 'https://maven.sumup.com/releases' }
    }
}
```
It would be helpful if this step could be included into readme.md so people would know.
Test it on your existing application and accept the pull request if it works ;)